### PR TITLE
Renderer Feature: support collection lists while rendering

### DIFF
--- a/dist/library/canvas.js
+++ b/dist/library/canvas.js
@@ -21,6 +21,11 @@ var EditableCanvas = class {
     });
     this.attachDocumentListener();
   }
+  update() {
+    this.cleanupListeners();
+    this.elements.all = Array.from(this.canvas.querySelectorAll(this.selectAll));
+    this.initialize();
+  }
   /**
    * Enable editing for a specific element.
    */

--- a/dist/library/pdf.js
+++ b/dist/library/pdf.js
@@ -23347,84 +23347,90 @@ var Renderer = class _Renderer {
     });
   }
   /**
-   * Render a `RenderElement`
+   * Render a `RenderElement` to all its instances
    */
-  renderElement(renderItem, canvas) {
-    const selector = this.elementSelector(renderItem);
-    const newCanvases = canvas.querySelectorAll(selector);
-    if (!newCanvases.length) {
+  renderElement(renderElement, canvas) {
+    const selector = this.elementSelector(renderElement);
+    const htmlRenderElements = canvas.querySelectorAll(selector);
+    if (!htmlRenderElements.length) {
       console.warn(`Element "${selector}" was not found.`);
       return;
     }
-    newCanvases.forEach((newCanvas) => {
-      if (newCanvas.style.display === "none") {
-        newCanvas.style.removeProperty("display");
-      }
-      if (newCanvas.classList.contains("hide")) {
-        newCanvas.classList.remove("hide");
-      }
-      switch (this.readVisibilityControl(newCanvas)) {
-        case "emptyState":
-          const emptyStateElement = newCanvas.querySelector(`[${this.emptyStateAttr}]`);
-          if (this.shouldHideElement(renderItem)) {
-            emptyStateElement.classList.remove("hide");
-            if (emptyStateElement.style.display === "none") {
-              emptyStateElement.style.removeProperty("display");
-            }
-          } else {
-            emptyStateElement.classList.add("hide");
-            emptyStateElement.style.display = "none";
-          }
-          this._render(renderItem.fields, newCanvas);
-          break;
-        case true:
-          if (this.shouldHideElement(renderItem)) {
-            this.hideElement(newCanvas);
-          } else {
-            this._render(renderItem.fields, newCanvas);
-          }
-          break;
-        default:
-          this._render(renderItem.fields, newCanvas);
-          break;
-      }
+    htmlRenderElements.forEach((htmlRenderElement) => {
+      this.showElement(htmlRenderElement);
+      this.renderElementToTemplate(renderElement, htmlRenderElement);
     });
   }
   /**
-   * Render a `RenderField`
+   * Render a `RenderElement` to a single `HTMLRenderElement`
    */
-  renderField(field, canvas) {
-    const selector = this.fieldSelector(field);
+  renderElementToTemplate(renderElement, htmlTemplate) {
+    switch (this.readVisibilityControl(htmlTemplate)) {
+      case "emptyState":
+        const emptyStateElement = htmlTemplate.querySelector(`[${this.emptyStateAttr}]`);
+        if (this.shouldHideElement(renderElement)) {
+          emptyStateElement.classList.remove("hide");
+          if (emptyStateElement.style.display === "none") {
+            emptyStateElement.style.removeProperty("display");
+          }
+        } else {
+          emptyStateElement.classList.add("hide");
+          emptyStateElement.style.display = "none";
+        }
+        this._render(renderElement.fields, htmlTemplate);
+        break;
+      case true:
+        if (this.shouldHideElement(renderElement)) {
+          this.hideElement(htmlTemplate);
+        } else {
+          this._render(renderElement.fields, htmlTemplate);
+        }
+        break;
+      case false:
+      default:
+        this._render(renderElement.fields, htmlTemplate);
+        break;
+    }
+  }
+  /**
+   * Render a `RenderField` to all its instances
+   */
+  renderField(renderField, canvas) {
+    const selector = this.fieldSelector(renderField);
     const fields = canvas.querySelectorAll(selector);
-    fields.forEach((fieldElement) => {
-      if (!field.visibility || !field.value.trim()) {
-        switch (this.readVisibilityControl(fieldElement)) {
-          case "emptyState":
-            this.hideElement(fieldElement);
-            console.log(canvas);
-            break;
-          case true:
-            this.hideElement(fieldElement);
-            break;
-          case false:
-            break;
-          default:
-            break;
-        }
-      } else {
-        switch (field.type) {
-          case "html":
-            fieldElement.innerHTML = field.value;
-            break;
-          case "date":
-            const formatStr = fieldElement.dataset.dateFormat || "d.M.yyyy";
-            fieldElement.innerText = format(new Date(field.value), formatStr, { locale: de });
-            break;
-          default:
-            fieldElement.innerText = field.value;
-        }
-      }
+    fields.forEach((htmlRenderField) => {
+      this.renderFieldToTemplate(renderField, htmlRenderField);
     });
+  }
+  /**
+   * Render a `RenderField` to a single `HTMLRenderField`
+   */
+  renderFieldToTemplate(field, htmlTemplate) {
+    if (!field.visibility || !field.value.trim()) {
+      switch (this.readVisibilityControl(htmlTemplate)) {
+        case "emptyState":
+          this.hideElement(htmlTemplate);
+          break;
+        case true:
+          this.hideElement(htmlTemplate);
+          break;
+        case false:
+        default:
+          break;
+      }
+    } else {
+      switch (field.type) {
+        case "html":
+          htmlTemplate.innerHTML = field.value;
+          break;
+        case "date":
+          const formatStr = htmlTemplate.dataset.dateFormat || "d.M.yyyy";
+          htmlTemplate.innerText = format(new Date(field.value), formatStr, { locale: de });
+          break;
+        default:
+          htmlTemplate.innerText = field.value;
+      }
+    }
   }
   /**
    * Recursively reads the DOM node and its descendants to build a structured RenderData.
@@ -23570,6 +23576,14 @@ var Renderer = class _Renderer {
       }
       return false;
     });
+  }
+  showElement(element) {
+    if (element.style.display === "none") {
+      element.style.removeProperty("display");
+    }
+    if (element.classList.contains("hide")) {
+      element.classList.remove("hide");
+    }
   }
   hideElement(element) {
     const hideSelf = JSON.parse(element.getAttribute(`data-${this.attributeName}-hide-self`) || "false");

--- a/dist/library/renderer.js
+++ b/dist/library/renderer.js
@@ -3778,6 +3778,7 @@ var de = {
 var Renderer = class _Renderer {
   constructor(canvas, attributeName = "render") {
     this.attributeName = attributeName;
+    this.collectionAttr = `data-is-collection`;
     this.filterAttributes = {
       "data-filter": "string",
       "data-category": "string"
@@ -3816,8 +3817,38 @@ var Renderer = class _Renderer {
     }
     htmlRenderElements.forEach((htmlRenderElement) => {
       this.showElement(htmlRenderElement);
-      this.renderElementToTemplate(renderElement, htmlRenderElement);
+      let isCollection = htmlRenderElement.getAttribute(this.collectionAttr) === "true";
+      if (isCollection) {
+        this.renderCollection(renderElement, htmlRenderElement);
+      } else {
+        this.renderElementToTemplate(renderElement, htmlRenderElement);
+      }
     });
+  }
+  renderCollection(renderElement, htmlRenderCollection) {
+    let max = parseInt(htmlRenderCollection.getAttribute("data-limit-items") || "-1");
+    if (max === -1)
+      max = renderElement.fields.length;
+    max = Math.min(renderElement.fields.length, max);
+    max = Math.max(max, 0);
+    const firstChild = htmlRenderCollection.firstElementChild;
+    if (firstChild) {
+      const htmlTemplate = firstChild.cloneNode(true);
+      htmlRenderCollection.innerHTML = "";
+      const fragment = document.createDocumentFragment();
+      for (let i = 0; i < max; i++) {
+        const template = htmlTemplate.cloneNode(true);
+        if (_Renderer.isRenderElement(renderElement.fields[i])) {
+          this.renderElementToTemplate(renderElement.fields[i], template);
+        } else if (_Renderer.isRenderField(renderElement.fields[i])) {
+          this.renderFieldToTemplate(renderElement.fields[i], template);
+        }
+        fragment.appendChild(template);
+      }
+      htmlRenderCollection.appendChild(fragment);
+    } else {
+      console.warn("No first child found to clone");
+    }
   }
   /**
    * Render a `RenderElement` to a single `HTMLRenderElement`
@@ -3918,6 +3949,12 @@ var Renderer = class _Renderer {
     return renderData;
   }
   clear(node = this.canvas) {
+    const collections = node.querySelectorAll(`${this.elementSelector()}[${this.collectionAttr}]`);
+    collections.forEach((collection) => {
+      const template = collection.firstElementChild.cloneNode(true);
+      collection.innerHTML = "";
+      collection.appendChild(template);
+    });
     node.querySelectorAll(this.fieldSelector()).forEach((field) => field.innerText = "");
   }
   readRenderElement(child, stopRecursionAttributes) {
@@ -4069,6 +4106,9 @@ var Renderer = class _Renderer {
   }
   elementSelector(element) {
     const elementAttrSelector = attributeselector_default(this.elementAttr);
+    if (!element) {
+      return elementAttrSelector();
+    }
     let selectorString = elementAttrSelector(element.element);
     if (element.instance) {
       selectorString += this.instanceSelector(element.element, element.instance);

--- a/dist/library/renderer.js
+++ b/dist/library/renderer.js
@@ -3807,46 +3807,48 @@ var Renderer = class _Renderer {
   /**
    * Render a `RenderElement`
    */
-  renderElement(renderItem, canvas) {
-    const selector = this.elementSelector(renderItem);
-    const newCanvases = canvas.querySelectorAll(selector);
-    if (!newCanvases.length) {
+  renderElement(renderElement, canvas) {
+    const selector = this.elementSelector(renderElement);
+    const htmlRenderElements = canvas.querySelectorAll(selector);
+    if (!htmlRenderElements.length) {
       console.warn(`Element "${selector}" was not found.`);
       return;
     }
-    newCanvases.forEach((newCanvas) => {
-      if (newCanvas.style.display === "none") {
-        newCanvas.style.removeProperty("display");
-      }
-      if (newCanvas.classList.contains("hide")) {
-        newCanvas.classList.remove("hide");
-      }
-      switch (this.readVisibilityControl(newCanvas)) {
-        case "emptyState":
-          const emptyStateElement = newCanvas.querySelector(`[${this.emptyStateAttr}]`);
-          if (this.shouldHideElement(renderItem)) {
-            emptyStateElement.classList.remove("hide");
-            if (emptyStateElement.style.display === "none") {
-              emptyStateElement.style.removeProperty("display");
-            }
-          } else {
-            emptyStateElement.classList.add("hide");
-            emptyStateElement.style.display = "none";
-          }
-          this._render(renderItem.fields, newCanvas);
-          break;
-        case true:
-          if (this.shouldHideElement(renderItem)) {
-            this.hideElement(newCanvas);
-          } else {
-            this._render(renderItem.fields, newCanvas);
-          }
-          break;
-        default:
-          this._render(renderItem.fields, newCanvas);
-          break;
-      }
+    htmlRenderElements.forEach((htmlRenderElement) => {
+      this.showElement(htmlRenderElement);
+      this.renderElementToTemplate(renderElement, htmlRenderElement);
     });
+  }
+  /**
+   * Render a `RenderElement` on a single `HTMLRenderElement`
+   */
+  renderElementToTemplate(renderElement, htmlTemplate) {
+    switch (this.readVisibilityControl(htmlTemplate)) {
+      case "emptyState":
+        const emptyStateElement = htmlTemplate.querySelector(`[${this.emptyStateAttr}]`);
+        if (this.shouldHideElement(renderElement)) {
+          emptyStateElement.classList.remove("hide");
+          if (emptyStateElement.style.display === "none") {
+            emptyStateElement.style.removeProperty("display");
+          }
+        } else {
+          emptyStateElement.classList.add("hide");
+          emptyStateElement.style.display = "none";
+        }
+        this._render(renderElement.fields, htmlTemplate);
+        break;
+      case true:
+        if (this.shouldHideElement(renderElement)) {
+          this.hideElement(htmlTemplate);
+        } else {
+          this._render(renderElement.fields, htmlTemplate);
+        }
+        break;
+      case false:
+      default:
+        this._render(renderElement.fields, htmlTemplate);
+        break;
+    }
   }
   /**
    * Render a `RenderField`
@@ -4028,6 +4030,14 @@ var Renderer = class _Renderer {
       }
       return false;
     });
+  }
+  showElement(element) {
+    if (element.style.display === "none") {
+      element.style.removeProperty("display");
+    }
+    if (element.classList.contains("hide")) {
+      element.classList.remove("hide");
+    }
   }
   hideElement(element) {
     const hideSelf = JSON.parse(element.getAttribute(`data-${this.attributeName}-hide-self`) || "false");

--- a/dist/library/renderer.js
+++ b/dist/library/renderer.js
@@ -3805,7 +3805,7 @@ var Renderer = class _Renderer {
     });
   }
   /**
-   * Render a `RenderElement`
+   * Render a `RenderElement` to all its instances
    */
   renderElement(renderElement, canvas) {
     const selector = this.elementSelector(renderElement);
@@ -3820,7 +3820,7 @@ var Renderer = class _Renderer {
     });
   }
   /**
-   * Render a `RenderElement` on a single `HTMLRenderElement`
+   * Render a `RenderElement` to a single `HTMLRenderElement`
    */
   renderElementToTemplate(renderElement, htmlTemplate) {
     switch (this.readVisibilityControl(htmlTemplate)) {
@@ -3851,40 +3851,44 @@ var Renderer = class _Renderer {
     }
   }
   /**
-   * Render a `RenderField`
+   * Render a `RenderField` to all its instances
    */
-  renderField(field, canvas) {
-    const selector = this.fieldSelector(field);
+  renderField(renderField, canvas) {
+    const selector = this.fieldSelector(renderField);
     const fields = canvas.querySelectorAll(selector);
-    fields.forEach((fieldElement) => {
-      if (!field.visibility || !field.value.trim()) {
-        switch (this.readVisibilityControl(fieldElement)) {
-          case "emptyState":
-            this.hideElement(fieldElement);
-            console.log(canvas);
-            break;
-          case true:
-            this.hideElement(fieldElement);
-            break;
-          case false:
-            break;
-          default:
-            break;
-        }
-      } else {
-        switch (field.type) {
-          case "html":
-            fieldElement.innerHTML = field.value;
-            break;
-          case "date":
-            const formatStr = fieldElement.dataset.dateFormat || "d.M.yyyy";
-            fieldElement.innerText = format(new Date(field.value), formatStr, { locale: de });
-            break;
-          default:
-            fieldElement.innerText = field.value;
-        }
-      }
+    fields.forEach((htmlRenderField) => {
+      this.renderFieldToTemplate(renderField, htmlRenderField);
     });
+  }
+  /**
+   * Render a `RenderField` to a single `HTMLRenderField`
+   */
+  renderFieldToTemplate(field, htmlTemplate) {
+    if (!field.visibility || !field.value.trim()) {
+      switch (this.readVisibilityControl(htmlTemplate)) {
+        case "emptyState":
+          this.hideElement(htmlTemplate);
+          break;
+        case true:
+          this.hideElement(htmlTemplate);
+          break;
+        case false:
+        default:
+          break;
+      }
+    } else {
+      switch (field.type) {
+        case "html":
+          htmlTemplate.innerHTML = field.value;
+          break;
+        case "date":
+          const formatStr = htmlTemplate.dataset.dateFormat || "d.M.yyyy";
+          htmlTemplate.innerText = format(new Date(field.value), formatStr, { locale: de });
+          break;
+        default:
+          htmlTemplate.innerText = field.value;
+      }
+    }
   }
   /**
    * Recursively reads the DOM node and its descendants to build a structured RenderData.

--- a/dist/sanavita-activity.js
+++ b/dist/sanavita-activity.js
@@ -23479,84 +23479,90 @@
       });
     }
     /**
-     * Render a `RenderElement`
+     * Render a `RenderElement` to all its instances
      */
-    renderElement(renderItem, canvas) {
-      const selector = this.elementSelector(renderItem);
-      const newCanvases = canvas.querySelectorAll(selector);
-      if (!newCanvases.length) {
+    renderElement(renderElement, canvas) {
+      const selector = this.elementSelector(renderElement);
+      const htmlRenderElements = canvas.querySelectorAll(selector);
+      if (!htmlRenderElements.length) {
         console.warn(`Element "${selector}" was not found.`);
         return;
       }
-      newCanvases.forEach((newCanvas) => {
-        if (newCanvas.style.display === "none") {
-          newCanvas.style.removeProperty("display");
-        }
-        if (newCanvas.classList.contains("hide")) {
-          newCanvas.classList.remove("hide");
-        }
-        switch (this.readVisibilityControl(newCanvas)) {
-          case "emptyState":
-            const emptyStateElement = newCanvas.querySelector(`[${this.emptyStateAttr}]`);
-            if (this.shouldHideElement(renderItem)) {
-              emptyStateElement.classList.remove("hide");
-              if (emptyStateElement.style.display === "none") {
-                emptyStateElement.style.removeProperty("display");
-              }
-            } else {
-              emptyStateElement.classList.add("hide");
-              emptyStateElement.style.display = "none";
-            }
-            this._render(renderItem.fields, newCanvas);
-            break;
-          case true:
-            if (this.shouldHideElement(renderItem)) {
-              this.hideElement(newCanvas);
-            } else {
-              this._render(renderItem.fields, newCanvas);
-            }
-            break;
-          default:
-            this._render(renderItem.fields, newCanvas);
-            break;
-        }
+      htmlRenderElements.forEach((htmlRenderElement) => {
+        this.showElement(htmlRenderElement);
+        this.renderElementToTemplate(renderElement, htmlRenderElement);
       });
     }
     /**
-     * Render a `RenderField`
+     * Render a `RenderElement` to a single `HTMLRenderElement`
      */
-    renderField(field, canvas) {
-      const selector = this.fieldSelector(field);
+    renderElementToTemplate(renderElement, htmlTemplate) {
+      switch (this.readVisibilityControl(htmlTemplate)) {
+        case "emptyState":
+          const emptyStateElement = htmlTemplate.querySelector(`[${this.emptyStateAttr}]`);
+          if (this.shouldHideElement(renderElement)) {
+            emptyStateElement.classList.remove("hide");
+            if (emptyStateElement.style.display === "none") {
+              emptyStateElement.style.removeProperty("display");
+            }
+          } else {
+            emptyStateElement.classList.add("hide");
+            emptyStateElement.style.display = "none";
+          }
+          this._render(renderElement.fields, htmlTemplate);
+          break;
+        case true:
+          if (this.shouldHideElement(renderElement)) {
+            this.hideElement(htmlTemplate);
+          } else {
+            this._render(renderElement.fields, htmlTemplate);
+          }
+          break;
+        case false:
+        default:
+          this._render(renderElement.fields, htmlTemplate);
+          break;
+      }
+    }
+    /**
+     * Render a `RenderField` to all its instances
+     */
+    renderField(renderField, canvas) {
+      const selector = this.fieldSelector(renderField);
       const fields = canvas.querySelectorAll(selector);
-      fields.forEach((fieldElement) => {
-        if (!field.visibility || !field.value.trim()) {
-          switch (this.readVisibilityControl(fieldElement)) {
-            case "emptyState":
-              this.hideElement(fieldElement);
-              console.log(canvas);
-              break;
-            case true:
-              this.hideElement(fieldElement);
-              break;
-            case false:
-              break;
-            default:
-              break;
-          }
-        } else {
-          switch (field.type) {
-            case "html":
-              fieldElement.innerHTML = field.value;
-              break;
-            case "date":
-              const formatStr = fieldElement.dataset.dateFormat || "d.M.yyyy";
-              fieldElement.innerText = format(new Date(field.value), formatStr, { locale: de });
-              break;
-            default:
-              fieldElement.innerText = field.value;
-          }
-        }
+      fields.forEach((htmlRenderField) => {
+        this.renderFieldToTemplate(renderField, htmlRenderField);
       });
+    }
+    /**
+     * Render a `RenderField` to a single `HTMLRenderField`
+     */
+    renderFieldToTemplate(field, htmlTemplate) {
+      if (!field.visibility || !field.value.trim()) {
+        switch (this.readVisibilityControl(htmlTemplate)) {
+          case "emptyState":
+            this.hideElement(htmlTemplate);
+            break;
+          case true:
+            this.hideElement(htmlTemplate);
+            break;
+          case false:
+          default:
+            break;
+        }
+      } else {
+        switch (field.type) {
+          case "html":
+            htmlTemplate.innerHTML = field.value;
+            break;
+          case "date":
+            const formatStr = htmlTemplate.dataset.dateFormat || "d.M.yyyy";
+            htmlTemplate.innerText = format(new Date(field.value), formatStr, { locale: de });
+            break;
+          default:
+            htmlTemplate.innerText = field.value;
+        }
+      }
     }
     /**
      * Recursively reads the DOM node and its descendants to build a structured RenderData.
@@ -23702,6 +23708,14 @@
         }
         return false;
       });
+    }
+    showElement(element) {
+      if (element.style.display === "none") {
+        element.style.removeProperty("display");
+      }
+      if (element.classList.contains("hide")) {
+        element.classList.remove("hide");
+      }
     }
     hideElement(element) {
       const hideSelf = JSON.parse(element.getAttribute(`data-${this.attributeName}-hide-self`) || "false");

--- a/dist/sanavita-menuplan.js
+++ b/dist/sanavita-menuplan.js
@@ -23479,84 +23479,90 @@
       });
     }
     /**
-     * Render a `RenderElement`
+     * Render a `RenderElement` to all its instances
      */
-    renderElement(renderItem, canvas) {
-      const selector = this.elementSelector(renderItem);
-      const newCanvases = canvas.querySelectorAll(selector);
-      if (!newCanvases.length) {
+    renderElement(renderElement, canvas) {
+      const selector = this.elementSelector(renderElement);
+      const htmlRenderElements = canvas.querySelectorAll(selector);
+      if (!htmlRenderElements.length) {
         console.warn(`Element "${selector}" was not found.`);
         return;
       }
-      newCanvases.forEach((newCanvas) => {
-        if (newCanvas.style.display === "none") {
-          newCanvas.style.removeProperty("display");
-        }
-        if (newCanvas.classList.contains("hide")) {
-          newCanvas.classList.remove("hide");
-        }
-        switch (this.readVisibilityControl(newCanvas)) {
-          case "emptyState":
-            const emptyStateElement = newCanvas.querySelector(`[${this.emptyStateAttr}]`);
-            if (this.shouldHideElement(renderItem)) {
-              emptyStateElement.classList.remove("hide");
-              if (emptyStateElement.style.display === "none") {
-                emptyStateElement.style.removeProperty("display");
-              }
-            } else {
-              emptyStateElement.classList.add("hide");
-              emptyStateElement.style.display = "none";
-            }
-            this._render(renderItem.fields, newCanvas);
-            break;
-          case true:
-            if (this.shouldHideElement(renderItem)) {
-              this.hideElement(newCanvas);
-            } else {
-              this._render(renderItem.fields, newCanvas);
-            }
-            break;
-          default:
-            this._render(renderItem.fields, newCanvas);
-            break;
-        }
+      htmlRenderElements.forEach((htmlRenderElement) => {
+        this.showElement(htmlRenderElement);
+        this.renderElementToTemplate(renderElement, htmlRenderElement);
       });
     }
     /**
-     * Render a `RenderField`
+     * Render a `RenderElement` to a single `HTMLRenderElement`
      */
-    renderField(field, canvas) {
-      const selector = this.fieldSelector(field);
+    renderElementToTemplate(renderElement, htmlTemplate) {
+      switch (this.readVisibilityControl(htmlTemplate)) {
+        case "emptyState":
+          const emptyStateElement = htmlTemplate.querySelector(`[${this.emptyStateAttr}]`);
+          if (this.shouldHideElement(renderElement)) {
+            emptyStateElement.classList.remove("hide");
+            if (emptyStateElement.style.display === "none") {
+              emptyStateElement.style.removeProperty("display");
+            }
+          } else {
+            emptyStateElement.classList.add("hide");
+            emptyStateElement.style.display = "none";
+          }
+          this._render(renderElement.fields, htmlTemplate);
+          break;
+        case true:
+          if (this.shouldHideElement(renderElement)) {
+            this.hideElement(htmlTemplate);
+          } else {
+            this._render(renderElement.fields, htmlTemplate);
+          }
+          break;
+        case false:
+        default:
+          this._render(renderElement.fields, htmlTemplate);
+          break;
+      }
+    }
+    /**
+     * Render a `RenderField` to all its instances
+     */
+    renderField(renderField, canvas) {
+      const selector = this.fieldSelector(renderField);
       const fields = canvas.querySelectorAll(selector);
-      fields.forEach((fieldElement) => {
-        if (!field.visibility || !field.value.trim()) {
-          switch (this.readVisibilityControl(fieldElement)) {
-            case "emptyState":
-              this.hideElement(fieldElement);
-              console.log(canvas);
-              break;
-            case true:
-              this.hideElement(fieldElement);
-              break;
-            case false:
-              break;
-            default:
-              break;
-          }
-        } else {
-          switch (field.type) {
-            case "html":
-              fieldElement.innerHTML = field.value;
-              break;
-            case "date":
-              const formatStr = fieldElement.dataset.dateFormat || "d.M.yyyy";
-              fieldElement.innerText = format(new Date(field.value), formatStr, { locale: de });
-              break;
-            default:
-              fieldElement.innerText = field.value;
-          }
-        }
+      fields.forEach((htmlRenderField) => {
+        this.renderFieldToTemplate(renderField, htmlRenderField);
       });
+    }
+    /**
+     * Render a `RenderField` to a single `HTMLRenderField`
+     */
+    renderFieldToTemplate(field, htmlTemplate) {
+      if (!field.visibility || !field.value.trim()) {
+        switch (this.readVisibilityControl(htmlTemplate)) {
+          case "emptyState":
+            this.hideElement(htmlTemplate);
+            break;
+          case true:
+            this.hideElement(htmlTemplate);
+            break;
+          case false:
+          default:
+            break;
+        }
+      } else {
+        switch (field.type) {
+          case "html":
+            htmlTemplate.innerHTML = field.value;
+            break;
+          case "date":
+            const formatStr = htmlTemplate.dataset.dateFormat || "d.M.yyyy";
+            htmlTemplate.innerText = format(new Date(field.value), formatStr, { locale: de });
+            break;
+          default:
+            htmlTemplate.innerText = field.value;
+        }
+      }
     }
     /**
      * Recursively reads the DOM node and its descendants to build a structured RenderData.
@@ -23702,6 +23708,14 @@
         }
         return false;
       });
+    }
+    showElement(element) {
+      if (element.style.display === "none") {
+        element.style.removeProperty("display");
+      }
+      if (element.classList.contains("hide")) {
+        element.classList.remove("hide");
+      }
     }
     hideElement(element) {
       const hideSelf = JSON.parse(element.getAttribute(`data-${this.attributeName}-hide-self`) || "false");

--- a/dist/sanavita-menuplan.js
+++ b/dist/sanavita-menuplan.js
@@ -19564,6 +19564,11 @@
       });
       this.attachDocumentListener();
     }
+    update() {
+      this.cleanupListeners();
+      this.elements.all = Array.from(this.canvas.querySelectorAll(this.selectAll));
+      this.initialize();
+    }
     /**
      * Enable editing for a specific element.
      */
@@ -23452,6 +23457,7 @@
   var Renderer = class _Renderer {
     constructor(canvas, attributeName = "render") {
       this.attributeName = attributeName;
+      this.collectionAttr = `data-is-collection`;
       this.filterAttributes = {
         "data-filter": "string",
         "data-category": "string"
@@ -23490,8 +23496,38 @@
       }
       htmlRenderElements.forEach((htmlRenderElement) => {
         this.showElement(htmlRenderElement);
-        this.renderElementToTemplate(renderElement, htmlRenderElement);
+        let isCollection = htmlRenderElement.getAttribute(this.collectionAttr) === "true";
+        if (isCollection) {
+          this.renderCollection(renderElement, htmlRenderElement);
+        } else {
+          this.renderElementToTemplate(renderElement, htmlRenderElement);
+        }
       });
+    }
+    renderCollection(renderElement, htmlRenderCollection) {
+      let max2 = parseInt(htmlRenderCollection.getAttribute("data-limit-items") || "-1");
+      if (max2 === -1)
+        max2 = renderElement.fields.length;
+      max2 = Math.min(renderElement.fields.length, max2);
+      max2 = Math.max(max2, 0);
+      const firstChild = htmlRenderCollection.firstElementChild;
+      if (firstChild) {
+        const htmlTemplate = firstChild.cloneNode(true);
+        htmlRenderCollection.innerHTML = "";
+        const fragment = document.createDocumentFragment();
+        for (let i3 = 0; i3 < max2; i3++) {
+          const template = htmlTemplate.cloneNode(true);
+          if (_Renderer.isRenderElement(renderElement.fields[i3])) {
+            this.renderElementToTemplate(renderElement.fields[i3], template);
+          } else if (_Renderer.isRenderField(renderElement.fields[i3])) {
+            this.renderFieldToTemplate(renderElement.fields[i3], template);
+          }
+          fragment.appendChild(template);
+        }
+        htmlRenderCollection.appendChild(fragment);
+      } else {
+        console.warn("No first child found to clone");
+      }
     }
     /**
      * Render a `RenderElement` to a single `HTMLRenderElement`
@@ -23592,6 +23628,12 @@
       return renderData;
     }
     clear(node2 = this.canvas) {
+      const collections = node2.querySelectorAll(`${this.elementSelector()}[${this.collectionAttr}]`);
+      collections.forEach((collection) => {
+        const template = collection.firstElementChild.cloneNode(true);
+        collection.innerHTML = "";
+        collection.appendChild(template);
+      });
       node2.querySelectorAll(this.fieldSelector()).forEach((field) => field.innerText = "");
     }
     readRenderElement(child, stopRecursionAttributes) {
@@ -23743,6 +23785,9 @@
     }
     elementSelector(element) {
       const elementAttrSelector = attributeselector_default(this.elementAttr);
+      if (!element) {
+        return elementAttrSelector();
+      }
       let selectorString = elementAttrSelector(element.element);
       if (element.instance) {
         selectorString += this.instanceSelector(element.element, element.instance);
@@ -33770,7 +33815,6 @@ Page:`, page);
     const drinksCollection = new FilterCollection(drinkLists_collectionListElement, "Getr\xE4nke", "pdf");
     drinksCollection.renderer.addFilterAttributes({ "start-date": "date", "end-date": "date" });
     drinksCollection.readData();
-    drinksCollection.debug = true;
     const pdf = new Pdf(pdfContainer);
     const filterForm = new FilterForm(filterFormElement);
     const canvas = new EditableCanvas(pdfContainer, ".pdf-h3");
@@ -33816,12 +33860,21 @@ Page:`, page);
           visibility: true
         }
       ];
-      pdf.render([
+      const renderCollections = [
+        {
+          element: "drink-list-collection",
+          fields: drinksCollection.filterByDateRange(startDate, endDate),
+          visibility: true
+        }
+      ];
+      const renderData = [
         ...staticRenderFields,
         ...filterCollection.filterByDate(startDate, endDate),
-        ...drinksCollection.filterByDateRange(startDate, endDate)
-      ]);
+        ...renderCollections
+      ];
       canvas.showHiddenElements();
+      pdf.render(renderData);
+      canvas.update();
     });
     filterForm.addOnChange(["scale"], (filters) => {
       const scale = parseFloat(filters.getField("scale").value);

--- a/dist/sanavita-pdf-test.js
+++ b/dist/sanavita-pdf-test.js
@@ -23620,84 +23620,90 @@
       });
     }
     /**
-     * Render a `RenderElement`
+     * Render a `RenderElement` to all its instances
      */
-    renderElement(renderItem, canvas) {
-      const selector = this.elementSelector(renderItem);
-      const newCanvases = canvas.querySelectorAll(selector);
-      if (!newCanvases.length) {
+    renderElement(renderElement, canvas) {
+      const selector = this.elementSelector(renderElement);
+      const htmlRenderElements = canvas.querySelectorAll(selector);
+      if (!htmlRenderElements.length) {
         console.warn(`Element "${selector}" was not found.`);
         return;
       }
-      newCanvases.forEach((newCanvas) => {
-        if (newCanvas.style.display === "none") {
-          newCanvas.style.removeProperty("display");
-        }
-        if (newCanvas.classList.contains("hide")) {
-          newCanvas.classList.remove("hide");
-        }
-        switch (this.readVisibilityControl(newCanvas)) {
-          case "emptyState":
-            const emptyStateElement = newCanvas.querySelector(`[${this.emptyStateAttr}]`);
-            if (this.shouldHideElement(renderItem)) {
-              emptyStateElement.classList.remove("hide");
-              if (emptyStateElement.style.display === "none") {
-                emptyStateElement.style.removeProperty("display");
-              }
-            } else {
-              emptyStateElement.classList.add("hide");
-              emptyStateElement.style.display = "none";
-            }
-            this._render(renderItem.fields, newCanvas);
-            break;
-          case true:
-            if (this.shouldHideElement(renderItem)) {
-              this.hideElement(newCanvas);
-            } else {
-              this._render(renderItem.fields, newCanvas);
-            }
-            break;
-          default:
-            this._render(renderItem.fields, newCanvas);
-            break;
-        }
+      htmlRenderElements.forEach((htmlRenderElement) => {
+        this.showElement(htmlRenderElement);
+        this.renderElementToTemplate(renderElement, htmlRenderElement);
       });
     }
     /**
-     * Render a `RenderField`
+     * Render a `RenderElement` to a single `HTMLRenderElement`
      */
-    renderField(field, canvas) {
-      const selector = this.fieldSelector(field);
+    renderElementToTemplate(renderElement, htmlTemplate) {
+      switch (this.readVisibilityControl(htmlTemplate)) {
+        case "emptyState":
+          const emptyStateElement = htmlTemplate.querySelector(`[${this.emptyStateAttr}]`);
+          if (this.shouldHideElement(renderElement)) {
+            emptyStateElement.classList.remove("hide");
+            if (emptyStateElement.style.display === "none") {
+              emptyStateElement.style.removeProperty("display");
+            }
+          } else {
+            emptyStateElement.classList.add("hide");
+            emptyStateElement.style.display = "none";
+          }
+          this._render(renderElement.fields, htmlTemplate);
+          break;
+        case true:
+          if (this.shouldHideElement(renderElement)) {
+            this.hideElement(htmlTemplate);
+          } else {
+            this._render(renderElement.fields, htmlTemplate);
+          }
+          break;
+        case false:
+        default:
+          this._render(renderElement.fields, htmlTemplate);
+          break;
+      }
+    }
+    /**
+     * Render a `RenderField` to all its instances
+     */
+    renderField(renderField, canvas) {
+      const selector = this.fieldSelector(renderField);
       const fields = canvas.querySelectorAll(selector);
-      fields.forEach((fieldElement) => {
-        if (!field.visibility || !field.value.trim()) {
-          switch (this.readVisibilityControl(fieldElement)) {
-            case "emptyState":
-              this.hideElement(fieldElement);
-              console.log(canvas);
-              break;
-            case true:
-              this.hideElement(fieldElement);
-              break;
-            case false:
-              break;
-            default:
-              break;
-          }
-        } else {
-          switch (field.type) {
-            case "html":
-              fieldElement.innerHTML = field.value;
-              break;
-            case "date":
-              const formatStr = fieldElement.dataset.dateFormat || "d.M.yyyy";
-              fieldElement.innerText = format(new Date(field.value), formatStr, { locale: de });
-              break;
-            default:
-              fieldElement.innerText = field.value;
-          }
-        }
+      fields.forEach((htmlRenderField) => {
+        this.renderFieldToTemplate(renderField, htmlRenderField);
       });
+    }
+    /**
+     * Render a `RenderField` to a single `HTMLRenderField`
+     */
+    renderFieldToTemplate(field, htmlTemplate) {
+      if (!field.visibility || !field.value.trim()) {
+        switch (this.readVisibilityControl(htmlTemplate)) {
+          case "emptyState":
+            this.hideElement(htmlTemplate);
+            break;
+          case true:
+            this.hideElement(htmlTemplate);
+            break;
+          case false:
+          default:
+            break;
+        }
+      } else {
+        switch (field.type) {
+          case "html":
+            htmlTemplate.innerHTML = field.value;
+            break;
+          case "date":
+            const formatStr = htmlTemplate.dataset.dateFormat || "d.M.yyyy";
+            htmlTemplate.innerText = format(new Date(field.value), formatStr, { locale: de });
+            break;
+          default:
+            htmlTemplate.innerText = field.value;
+        }
+      }
     }
     /**
      * Recursively reads the DOM node and its descendants to build a structured RenderData.
@@ -23843,6 +23849,14 @@
         }
         return false;
       });
+    }
+    showElement(element) {
+      if (element.style.display === "none") {
+        element.style.removeProperty("display");
+      }
+      if (element.classList.contains("hide")) {
+        element.classList.remove("hide");
+      }
     }
     hideElement(element) {
       const hideSelf = JSON.parse(element.getAttribute(`data-${this.attributeName}-hide-self`) || "false");

--- a/dist/screen.js
+++ b/dist/screen.js
@@ -3806,84 +3806,90 @@
       });
     }
     /**
-     * Render a `RenderElement`
+     * Render a `RenderElement` to all its instances
      */
-    renderElement(renderItem, canvas) {
-      const selector = this.elementSelector(renderItem);
-      const newCanvases = canvas.querySelectorAll(selector);
-      if (!newCanvases.length) {
+    renderElement(renderElement, canvas) {
+      const selector = this.elementSelector(renderElement);
+      const htmlRenderElements = canvas.querySelectorAll(selector);
+      if (!htmlRenderElements.length) {
         console.warn(`Element "${selector}" was not found.`);
         return;
       }
-      newCanvases.forEach((newCanvas) => {
-        if (newCanvas.style.display === "none") {
-          newCanvas.style.removeProperty("display");
-        }
-        if (newCanvas.classList.contains("hide")) {
-          newCanvas.classList.remove("hide");
-        }
-        switch (this.readVisibilityControl(newCanvas)) {
-          case "emptyState":
-            const emptyStateElement = newCanvas.querySelector(`[${this.emptyStateAttr}]`);
-            if (this.shouldHideElement(renderItem)) {
-              emptyStateElement.classList.remove("hide");
-              if (emptyStateElement.style.display === "none") {
-                emptyStateElement.style.removeProperty("display");
-              }
-            } else {
-              emptyStateElement.classList.add("hide");
-              emptyStateElement.style.display = "none";
-            }
-            this._render(renderItem.fields, newCanvas);
-            break;
-          case true:
-            if (this.shouldHideElement(renderItem)) {
-              this.hideElement(newCanvas);
-            } else {
-              this._render(renderItem.fields, newCanvas);
-            }
-            break;
-          default:
-            this._render(renderItem.fields, newCanvas);
-            break;
-        }
+      htmlRenderElements.forEach((htmlRenderElement) => {
+        this.showElement(htmlRenderElement);
+        this.renderElementToTemplate(renderElement, htmlRenderElement);
       });
     }
     /**
-     * Render a `RenderField`
+     * Render a `RenderElement` to a single `HTMLRenderElement`
      */
-    renderField(field, canvas) {
-      const selector = this.fieldSelector(field);
+    renderElementToTemplate(renderElement, htmlTemplate) {
+      switch (this.readVisibilityControl(htmlTemplate)) {
+        case "emptyState":
+          const emptyStateElement = htmlTemplate.querySelector(`[${this.emptyStateAttr}]`);
+          if (this.shouldHideElement(renderElement)) {
+            emptyStateElement.classList.remove("hide");
+            if (emptyStateElement.style.display === "none") {
+              emptyStateElement.style.removeProperty("display");
+            }
+          } else {
+            emptyStateElement.classList.add("hide");
+            emptyStateElement.style.display = "none";
+          }
+          this._render(renderElement.fields, htmlTemplate);
+          break;
+        case true:
+          if (this.shouldHideElement(renderElement)) {
+            this.hideElement(htmlTemplate);
+          } else {
+            this._render(renderElement.fields, htmlTemplate);
+          }
+          break;
+        case false:
+        default:
+          this._render(renderElement.fields, htmlTemplate);
+          break;
+      }
+    }
+    /**
+     * Render a `RenderField` to all its instances
+     */
+    renderField(renderField, canvas) {
+      const selector = this.fieldSelector(renderField);
       const fields = canvas.querySelectorAll(selector);
-      fields.forEach((fieldElement) => {
-        if (!field.visibility || !field.value.trim()) {
-          switch (this.readVisibilityControl(fieldElement)) {
-            case "emptyState":
-              this.hideElement(fieldElement);
-              console.log(canvas);
-              break;
-            case true:
-              this.hideElement(fieldElement);
-              break;
-            case false:
-              break;
-            default:
-              break;
-          }
-        } else {
-          switch (field.type) {
-            case "html":
-              fieldElement.innerHTML = field.value;
-              break;
-            case "date":
-              const formatStr = fieldElement.dataset.dateFormat || "d.M.yyyy";
-              fieldElement.innerText = format(new Date(field.value), formatStr, { locale: de });
-              break;
-            default:
-              fieldElement.innerText = field.value;
-          }
-        }
+      fields.forEach((htmlRenderField) => {
+        this.renderFieldToTemplate(renderField, htmlRenderField);
       });
+    }
+    /**
+     * Render a `RenderField` to a single `HTMLRenderField`
+     */
+    renderFieldToTemplate(field, htmlTemplate) {
+      if (!field.visibility || !field.value.trim()) {
+        switch (this.readVisibilityControl(htmlTemplate)) {
+          case "emptyState":
+            this.hideElement(htmlTemplate);
+            break;
+          case true:
+            this.hideElement(htmlTemplate);
+            break;
+          case false:
+          default:
+            break;
+        }
+      } else {
+        switch (field.type) {
+          case "html":
+            htmlTemplate.innerHTML = field.value;
+            break;
+          case "date":
+            const formatStr = htmlTemplate.dataset.dateFormat || "d.M.yyyy";
+            htmlTemplate.innerText = format(new Date(field.value), formatStr, { locale: de });
+            break;
+          default:
+            htmlTemplate.innerText = field.value;
+        }
+      }
     }
     /**
      * Recursively reads the DOM node and its descendants to build a structured RenderData.
@@ -4029,6 +4035,14 @@
         }
         return false;
       });
+    }
+    showElement(element) {
+      if (element.style.display === "none") {
+        element.style.removeProperty("display");
+      }
+      if (element.classList.contains("hide")) {
+        element.classList.remove("hide");
+      }
     }
     hideElement(element) {
       const hideSelf = JSON.parse(element.getAttribute(`data-${this.attributeName}-hide-self`) || "false");

--- a/library/canvas.ts
+++ b/library/canvas.ts
@@ -34,6 +34,12 @@ export default class EditableCanvas {
     this.attachDocumentListener();
   }
 
+  public update(): void {
+    this.cleanupListeners();
+    this.elements.all = Array.from(this.canvas.querySelectorAll<HTMLElement>(this.selectAll));
+    this.initialize();
+  }
+
   /**
    * Enable editing for a specific element.
    */

--- a/library/renderer.ts
+++ b/library/renderer.ts
@@ -67,7 +67,7 @@ class Renderer {
   }
 
   /**
-   * Render a `RenderElement`
+   * Render a `RenderElement` to all its instances
    */
   private renderElement(renderElement: RenderElement, canvas: HTMLElement) {
     const selector = this.elementSelector(renderElement);
@@ -86,7 +86,7 @@ class Renderer {
   }
 
   /**
-   * Render a `RenderElement` on a single `HTMLRenderElement`
+   * Render a `RenderElement` to a single `HTMLRenderElement`
    */
   private renderElementToTemplate(renderElement: RenderElement, htmlTemplate: HTMLElement) {
     switch (this.readVisibilityControl(htmlTemplate)) {
@@ -119,40 +119,45 @@ class Renderer {
   }
 
   /**
-   * Render a `RenderField`
+   * Render a `RenderField` to all its instances
    */
-  private renderField(field: RenderField, canvas: HTMLElement) {
-    const selector = this.fieldSelector(field);
+  private renderField(renderField: RenderField, canvas: HTMLElement) {
+    const selector = this.fieldSelector(renderField);
     const fields: NodeListOf<HTMLElement> = canvas.querySelectorAll(selector);
-    fields.forEach((fieldElement) => {
-      if (!field.visibility || !field.value.trim()) {
-        switch (this.readVisibilityControl(fieldElement)) {
-          case "emptyState":
-            this.hideElement(fieldElement); // Hide empty field
-            console.log(canvas);
-            break;
-          case true:
-            this.hideElement(fieldElement); // Hide empty field
-            break;
-          case false:
-            break;
-          default:
-            break;
-        }
-      } else {
-        switch (field.type) {
-          case 'html':
-            fieldElement.innerHTML = field.value;
-            break;
-          case 'date':
-            const formatStr = fieldElement.dataset.dateFormat || 'd.M.yyyy';
-            fieldElement.innerText = format(new Date(field.value), formatStr, { locale: de });
-            break;
-          default:
-            fieldElement.innerText = field.value;
-        }
-      }
+    fields.forEach((htmlRenderField) => {
+      this.renderFieldToTemplate(renderField, htmlRenderField)
     });
+  }
+
+  /**
+   * Render a `RenderField` to a single `HTMLRenderField`
+   */
+  private renderFieldToTemplate(field: RenderField, htmlTemplate: HTMLElement) {
+    if (!field.visibility || !field.value.trim()) {
+      switch (this.readVisibilityControl(htmlTemplate)) {
+        case "emptyState":
+          this.hideElement(htmlTemplate); // Hide empty field
+          break;
+        case true:
+          this.hideElement(htmlTemplate); // Hide empty field
+          break;
+        case false:
+        default:
+          break;
+      }
+    } else {
+      switch (field.type) {
+        case 'html':
+          htmlTemplate.innerHTML = field.value;
+          break;
+        case 'date':
+          const formatStr = htmlTemplate.dataset.dateFormat || 'd.M.yyyy';
+          htmlTemplate.innerText = format(new Date(field.value), formatStr, { locale: de });
+          break;
+        default:
+          htmlTemplate.innerText = field.value;
+      }
+    }
   }
 
   /**

--- a/library/renderer.ts
+++ b/library/renderer.ts
@@ -384,8 +384,12 @@ class Renderer {
     });
   }
 
-  private elementSelector(element: RenderElement): string {
+  private elementSelector(element?: RenderElement): string {
     const elementAttrSelector = createAttribute(this.elementAttr);
+    if (!element) {
+      return elementAttrSelector();
+    }
+
     let selectorString = elementAttrSelector(element.element);
     if (element.instance) {
       selectorString += this.instanceSelector(element.element, element.instance);

--- a/src/ts/sanavita-activity.ts
+++ b/src/ts/sanavita-activity.ts
@@ -152,7 +152,7 @@ function initialize(): void {
   const pdfStorage = parsePdfLocalStorage();
 
   // Initialize collection list and pdf
-  const filterCollection = new FilterCollection(filterCollectionListElement, 'pdf');
+  const filterCollection = new FilterCollection(filterCollectionListElement, 'Aktivitäten', 'pdf');
   const pdf = new Pdf(pdfContainer);
   const filterForm = new FilterForm<FieldIds>(filterFormElement);
   const canvas = new EditableCanvas(pdfContainer, '.pdf-h3');

--- a/src/ts/sanavita-menuplan.ts
+++ b/src/ts/sanavita-menuplan.ts
@@ -2,7 +2,7 @@
 import EditableCanvas from '@library/canvas';
 import Pdf from '@library/pdf';
 import { FilterCollection } from '@library/wfcollection';
-import { RenderData, RenderField } from '@library/renderer';
+import { RenderData, RenderElement, RenderField } from '@library/renderer';
 import { CalendarweekComponent, FilterForm, filterFormSelector } from '@library/form';
 
 // Utility functions
@@ -148,7 +148,6 @@ function initialize(): void {
   const drinksCollection = new FilterCollection(drinkLists_collectionListElement, 'Getränke', 'pdf');
   drinksCollection.renderer.addFilterAttributes({ 'start-date': 'date', 'end-date': 'date' });
   drinksCollection.readData();
-  drinksCollection.debug = true;
 
   const pdf = new Pdf(pdfContainer);
   const filterForm = new FilterForm<FieldIds>(filterFormElement);
@@ -208,13 +207,23 @@ function initialize(): void {
       },
     ];
 
-    pdf.render([
+    const renderCollections: RenderElement[] = [
+      {
+        element: 'drink-list-collection',
+        fields: drinksCollection.filterByDateRange(startDate, endDate),
+        visibility: true,
+      }
+    ]
+
+    const renderData: RenderData = [
       ...staticRenderFields,
       ...filterCollection.filterByDate(startDate, endDate),
-      ...drinksCollection.filterByDateRange(startDate, endDate),
-    ]);
+      ...renderCollections,
+    ];
 
     canvas.showHiddenElements();
+    pdf.render(renderData);
+    canvas.update();
   });
 
   filterForm.addOnChange(['scale'], (filters) => {


### PR DESCRIPTION
### Summary
This new feature allows you to render `RenderData` inside a `RenderElement` which is marked as a collection list with the HTML attribute `data-is-collection="true"`.

### How it works
When your `Renderer` instance starts to render a `RenderElement` which is marked as a collection list:

1. It takes the `firstElementChild` of the collection list as a template.
2. It determines the item limit (`type number`) using the HTML attribute `data-item-limit`.
3. It starts at the first `field` of the `RenderElement`, clones the template, populates it with data, adds the new item to a `DocumentFragment`.
4. It stops at the item limit or renders all items if no item limit is provided.
5. Finally, it adds the `DocumentFragment` to the HTMLElement representing the `RenderElement` collection list.

